### PR TITLE
Rename PREFIX to DATADIR to avoid confusion

### DIFF
--- a/kenbuild/bstub.c
+++ b/kenbuild/bstub.c
@@ -73,9 +73,9 @@ int ExtInit(void)
 	getch();
 	*/
 
-#if defined(PREFIX)
+#if defined(DATADIR)
     {
-        const char *prefixdir = PREFIX;
+        const char *prefixdir = DATADIR;
         if (prefixdir && prefixdir[0]) {
             addsearchpath(prefixdir);
         }

--- a/kenbuild/game.c
+++ b/kenbuild/game.c
@@ -403,9 +403,9 @@ int app_main(int argc, char const * const argv[])
     int startretval = STARTWIN_RUN;
     struct startwin_settings settings;
 
-#if defined(PREFIX)
+#if defined(DATADIR)
     {
-        const char *prefixdir = PREFIX;
+        const char *prefixdir = DATADIR;
         if (prefixdir && prefixdir[0]) {
             addsearchpath(prefixdir);
         }


### PR DESCRIPTION
PREFIX is only used to access game data (and does not serve as a target PREFIX for installations), so rename it to DATADIR to avoid confusion.

This pull request is tied to the same one in the jfsw repo.