### PR TITLE
Make the USE_OPENGL=0 and USE_POLYMOST=0 engine library leaner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,19 +82,6 @@ ENGINEOBJS+= \
 	$(SRC)/crc32.$o \
 	$(SRC)/defs.$o \
 	$(SRC)/engine.$o \
-	$(SRC)/polymost.$o \
-	$(SRC)/polymost_fs.$o \
-	$(SRC)/polymost_vs.$o \
-	$(SRC)/polymostaux_fs.$o \
-	$(SRC)/polymostaux_vs.$o \
-	$(SRC)/polymosttex.$o \
-	$(SRC)/polymosttexcache.$o \
-	$(SRC)/polymosttexcompress.$o \
-	$(SRC)/hightile.$o \
-	$(SRC)/mdsprite.$o \
-	$(SRC)/glbuild.$o \
-	$(SRC)/glbuild_fs.$o \
-	$(SRC)/glbuild_vs.$o \
 	$(SRC)/kplib.$o \
 	$(SRC)/mmulti.$o \
 	$(SRC)/osd.$o \
@@ -102,6 +89,25 @@ ENGINEOBJS+= \
 	$(SRC)/scriptfile.$o \
 	$(SRC)/textfont.$o \
 	$(SRC)/smalltextfont.$o
+
+ifeq ($(USE_POLYMOST),1)
+	ENGINEOBJS+= $(SRC)/polymost.$o
+	ifeq ($(USE_OPENGL),1)
+		ENGINEOBJS+= \
+			$(SRC)/glbuild.$o \
+			$(SRC)/glbuild_fs.$o \
+			$(SRC)/glbuild_vs.$o \
+			$(SRC)/hightile.$o \
+			$(SRC)/mdsprite.$o \
+			$(SRC)/polymost_fs.$o \
+			$(SRC)/polymost_vs.$o \
+			$(SRC)/polymostaux_fs.$o \
+			$(SRC)/polymostaux_vs.$o \
+			$(SRC)/polymosttex.$o \
+			$(SRC)/polymosttexcache.$o \
+			$(SRC)/polymosttexcompress.$o
+	endif
+endif
 
 EDITOROBJS=$(SRC)/build.$o \
 	$(SRC)/config.$o
@@ -115,17 +121,19 @@ EDITOREXEOBJS=$(GAME)/bstub.$o \
 	$(EDITORLIB) \
 	$(ENGINELIB)
 
-ENGINEOBJS+= \
-	$(SRC)/rg_etc1.$o \
-	$(LIBSQUISH)/alpha.$o \
-	$(LIBSQUISH)/clusterfit.$o \
-	$(LIBSQUISH)/colourblock.$o \
-	$(LIBSQUISH)/colourfit.$o \
-	$(LIBSQUISH)/colourset.$o \
-	$(LIBSQUISH)/maths.$o \
-	$(LIBSQUISH)/rangefit.$o \
-	$(LIBSQUISH)/singlecolourfit.$o \
-	$(LIBSQUISH)/squish.$o
+ifeq ($(USE_OPENGL),1)
+	ENGINEOBJS+= \
+		$(SRC)/rg_etc1.$o \
+		$(LIBSQUISH)/alpha.$o \
+		$(LIBSQUISH)/clusterfit.$o \
+		$(LIBSQUISH)/colourblock.$o \
+		$(LIBSQUISH)/colourfit.$o \
+		$(LIBSQUISH)/colourset.$o \
+		$(LIBSQUISH)/maths.$o \
+		$(LIBSQUISH)/rangefit.$o \
+		$(LIBSQUISH)/singlecolourfit.$o \
+		$(LIBSQUISH)/squish.$o
+endif
 
 # detect the platform
 ifeq ($(PLATFORM),LINUX)

--- a/Makefile
+++ b/Makefile
@@ -90,9 +90,9 @@ ENGINEOBJS+= \
 	$(SRC)/textfont.$o \
 	$(SRC)/smalltextfont.$o
 
-ifeq ($(USE_POLYMOST),1)
+ifneq ($(USE_POLYMOST),0)
 	ENGINEOBJS+= $(SRC)/polymost.$o
-	ifeq ($(USE_OPENGL),1)
+	ifneq ($(USE_OPENGL),0)
 		ENGINEOBJS+= \
 			$(SRC)/glbuild.$o \
 			$(SRC)/glbuild_fs.$o \
@@ -121,7 +121,7 @@ EDITOREXEOBJS=$(GAME)/bstub.$o \
 	$(EDITORLIB) \
 	$(ENGINELIB)
 
-ifeq ($(USE_OPENGL),1)
+ifneq ($(USE_OPENGL),0)
 	ENGINEOBJS+= \
 		$(SRC)/rg_etc1.$o \
 		$(LIBSQUISH)/alpha.$o \

--- a/src/cache1d.c
+++ b/src/cache1d.c
@@ -938,6 +938,7 @@ CACHE1D_FIND_REC *klistpath(const char *_path, const char *mask, int type)
 		} while (search);
 	}
 
+#ifdef WITHKPLIB
 	if (!pathsearchmode) {	// next, zip files
 		char buf[BMAX_PATH], *p;
 		int i, j, ftype;
@@ -995,6 +996,7 @@ CACHE1D_FIND_REC *klistpath(const char *_path, const char *mask, int type)
 			}
 		}
 	}
+#endif
 	
 	// then, grp files
 	if (!pathsearchmode && !*path && (type & CACHE1D_FIND_FILE)) {


### PR DESCRIPTION
Even without USE_OPENGL and USE_POLYMOST the related source files were still compiled, and later left out by the linker. I made some changes to the Makefile so these files are not compiled when they are not needed. I also tacked in a small change in cache1d, where a WITHKPLIB ifdef was missing around some zip code.