### PR TITLE
Add the missing extern "C" to some headers

### DIFF
--- a/include/mmulti.h
+++ b/include/mmulti.h
@@ -3,6 +3,10 @@
 #ifndef __mmulti_h__
 #define __mmulti_h__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define MAXMULTIPLAYERS 16
 
 #define MMULTI_MODE_MS  0
@@ -27,6 +31,10 @@ void sendpacket(int other, unsigned char *bufptr, int messleng);
 int getpacket(int *other, unsigned char *bufptr);
 void flushpackets(void);
 void genericmultifunction(int other, unsigned char *bufptr, int messleng, int command);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif	// __mmulti_h__
 

--- a/include/osd.h
+++ b/include/osd.h
@@ -16,6 +16,10 @@ typedef struct {
 #define OSDCMD_OK	0
 #define OSDCMD_SHOWHELP 1
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // initializes things
 void OSD_Init(void);
 
@@ -76,6 +80,10 @@ int OSD_Dispatch(const char *cmd);
 //   help = a short help string
 //   func = the entry point to the function
 int OSD_RegisterFunction(const char *name, const char *help, int (*func)(const osdfuncparm_t*));
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // __osd_h__
 

--- a/include/scriptfile.h
+++ b/include/scriptfile.h
@@ -1,3 +1,10 @@
+#ifndef __scriptfile_h__
+#define __scriptfile_h__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
     char *textbuf;
     unsigned int textlength;
@@ -27,3 +34,9 @@ int scriptfile_eof(scriptfile *sf);
 int scriptfile_getsymbolvalue(const char *name, int *val);
 int scriptfile_addsymbolvalue(const char *name, int val);
 void scriptfile_clearsymbols(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __scriptfile_h__

--- a/include/winlayer.h
+++ b/include/winlayer.h
@@ -5,6 +5,10 @@
 #ifndef __build_interface_layer__
 #define __build_interface_layer__ WIN
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int backgroundidle;	// set to 1 to tell winlayer to go to idle priority when inactive
 extern unsigned maxrefreshfreq;
 
@@ -15,6 +19,10 @@ intptr_t win_gethinstance(void);
 
 void win_allowtaskswitching(int onf);
 int win_checkinstance(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #include "baselayer.h"
 


### PR DESCRIPTION
Some headers were missing the extern "C" part which caused problems when they were included from C++. 