### PR TITLE
Added invalid socket checks in netsend and netread

### DIFF
--- a/src/mmulti.c
+++ b/src/mmulti.c
@@ -280,6 +280,13 @@ int netsend (int other, void *dabuf, int bufsiz) //0:buffer full... can't send
 		return 0;
 	}
 
+	if (IS_INVALID_SOCKET(mysock)) {
+#ifdef MMULTI_DEBUG_SENDRECV_WIRE
+		debugprintf("mmulti debug send error: invalid socket\n");
+#endif
+		return 0;
+	}
+
 #ifdef MMULTI_DEBUG_SENDRECV_WIRE
 	{
 		int i;
@@ -394,6 +401,13 @@ int netread (int *other, void *dabuf, int bufsiz) //0:no packets in buffer
 {
 	char msg_control[1024];
 	int i;
+
+	if (IS_INVALID_SOCKET(mysock)) {
+#ifdef MMULTI_DEBUG_SENDRECV_WIRE
+		debugprintf("mmulti debug recv error: invalid socket\n");
+#endif
+		return 0;
+	}
 
 #ifdef _WIN32
 	WSABUF iovec;


### PR DESCRIPTION
I noticed that after quitting a multiplayer game getpackets in Duke3D tries to read from the already closed socket. This is probably harmless on most systems as the TCP/IP stack should catch the -1 socket, but I added sanity checks to netsend and netread just in case. Also socket functions may be unsafe to call after netuninit does the cleanup.