### PR TITLE
don't use fstatat on mingw

### DIFF
--- a/src/compat.c
+++ b/src/compat.c
@@ -460,22 +460,22 @@ struct Bdirent*	Breaddir(BDIR *dir)
 	dirr->info.mtime = 0;
 
 #ifdef __MINGW32__
-    char *fn = (char *)malloc(Bstrlen(dirr->path) + 1 + dirr->info.namlen + 1);
-    Bsprintf(fn, "%s/%s", dirr->path, de->d_name);
+	char *fn = (char *)malloc(Bstrlen(dirr->path) + 1 + dirr->info.namlen + 1);
+	Bsprintf(fn, "%s/%s", dirr->path, de->d_name);
 
-    if (!Bstat(fn, &st))
-    {
-        dirr->info.mode = st.st_mode;
-        dirr->info.size = st.st_size;
-        dirr->info.mtime = st.st_mtime;
-    }
+	if (!Bstat(fn, &st))
+	{
+		dirr->info.mode = st.st_mode;
+		dirr->info.size = st.st_size;
+		dirr->info.mtime = st.st_mtime;
+	}
 
-    free(fn);
+	free(fn);
 #else
 	if (!fstatat(dirfd(dirr->dir), de->d_name, &st, 0)) {
 		dirr->info.mode = st.st_mode;
 		dirr->info.size = st.st_size;
- 		dirr->info.mtime = st.st_mtime;
+		dirr->info.mtime = st.st_mtime;
 	}
 #endif
 #endif


### PR DESCRIPTION
This just works around the missing fstatat, so that mingw builds work again. I used defines to make this work quickly, but I would love to use something better if possible.